### PR TITLE
Potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -134,6 +134,12 @@ export const logout = async (req, res) => {
 
 export const forgotPassword = async (req, res) => {
   const { email } = req.body;
+  if (typeof email !== "string") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid email format",
+    });
+  }
   try {
     const user = await User.findOne({ email });
     if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/DavitNazarov/Auth/security/code-scanning/4](https://github.com/DavitNazarov/Auth/security/code-scanning/4)

To fix this problem, we need to ensure that the `email` value used in the MongoDB query is a string and not an object or any other type. This can be done by checking the type of `email` before using it in the query. If `email` is not a string, the function should return an error response and not proceed with the query. This change should be made in the `forgotPassword` function, just after extracting `email` from `req.body` and before calling `User.findOne({ email })`. No new imports are needed, and the fix does not change existing functionality except to reject invalid input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
